### PR TITLE
do not use 'native' for glob in basic BUILD file rules

### DIFF
--- a/boost_deps.bzl
+++ b/boost_deps.bzl
@@ -14,7 +14,7 @@ def _get_repo_build_file_content(lib):
 
 cc_library(
     name = "{name}",
-    hdrs = native.glob([
+    hdrs = glob([
         "include/**/*.h",
         "include/**/*.hpp",
         "include/**/*.ipp",


### PR DESCRIPTION
After upgrading Bazel 0.27, there seems to be a breakage here wherein 'native' is not defined in the basic BUILDfile context. It was probably not needed in the first place, as the code being generated here *should* be interpreted as any other BUILD file.