### PR TITLE
add missing filesystem cpp files

### DIFF
--- a/boost_libraries.bzl
+++ b/boost_libraries.bzl
@@ -175,6 +175,8 @@ BOOST_LIBRARIES = [
         name = "filesystem",
         srcs = [
             "src/codecvt_error_category.cpp",
+            "src/directory.cpp",
+            "src/exception.cpp",
             "src/operations.cpp",
             "src/path_traits.cpp",
             "src/path.cpp",


### PR DESCRIPTION
This is one change I noticed that broke something I tried when I attempted to confirm that bumping from 1.71 to 1.72 was safe.