### PR TITLE
bump pin to 1.80.0

### DIFF
--- a/README
+++ b/README
@@ -24,4 +24,4 @@ cc_binary(
 
 Pull requests to add more boost libraries are welcome.
 
-Currently pinned to boost-1.79.0. Tested under linux and Windows.
+Currently pinned to boost-1.80.0. Tested under linux and Windows.

--- a/boost_libraries.bzl
+++ b/boost_libraries.bzl
@@ -7,7 +7,7 @@ def boost_library(
         deps = None):
     return {
         "name": name,
-        "version": "boost-1.79.0",
+        "version": "boost-1.80.0",
         "srcs": srcs,
         "textual_hdrs": textual_hdrs,
         "defines": (defines or []) + ["BOOST_ALL_NO_LIB"],


### PR DESCRIPTION
if it please you, we can bump to 1.80.0.

there are a couple libraries that deprecate c++11 support, `locale` deprecated c++03, and `GIL` (which does not yet have a build rule) is dropping c++11 entirely and will soon require c++17.

so, i'm not seeing any obviously breaking changes. if you have a proper testing environment for this set up that would be great. what few libraries i use seem to still work correctly.